### PR TITLE
avoid UnicodeDecodeError 

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ train_iter, dev_iter = mr(text_field, label_field, device=-1, repeat=False)
 # update args and print
 args.embed_num = len(text_field.vocab)
 args.class_num = len(label_field.vocab) - 1
-args.cuda = args.no_cuda and torch.cuda.is_available(); del args.no_cuda
+args.cuda = (not args.no_cuda) and torch.cuda.is_available(); del args.no_cuda
 args.kernel_sizes = [int(k) for k in args.kernel_sizes.split(',')]
 args.save_dir = os.path.join(args.save_dir, datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))
 
@@ -93,6 +93,9 @@ else :
         cnn = torch.load(args.snapshot)
     except :
         print("Sorry, This snapshot doesn't exist."); exit()
+
+if args.cuda:
+    cnn = cnn.cuda()
         
 
 # train or predict

--- a/model.py
+++ b/model.py
@@ -16,7 +16,8 @@ class  CNN_Text(nn.Module):
         Ks = args.kernel_sizes
 
         self.embed = nn.Embedding(V, D)
-        self.convs1 = [nn.Conv2d(Ci, Co, (K, D)) for K in Ks]
+        #self.convs1 = [nn.Conv2d(Ci, Co, (K, D)) for K in Ks]
+        self.convs1 = nn.ModuleList([nn.Conv2d(Ci, Co, (K, D)) for K in Ks])
         '''
         self.conv13 = nn.Conv2d(Ci, Co, (3, D))
         self.conv14 = nn.Conv2d(Ci, Co, (4, D))
@@ -38,9 +39,14 @@ class  CNN_Text(nn.Module):
             x = Variable(x)
 
         x = x.unsqueeze(1) # (N,Ci,W,D)
+
         x = [F.relu(conv(x)).squeeze(3) for conv in self.convs1] #[(N,Co,W), ...]*len(Ks)
+
+
         x = [F.max_pool1d(i, i.size(2)).squeeze(2) for i in x] #[(N,Co), ...]*len(Ks)
+
         x = torch.cat(x, 1)
+
         '''
         x1 = self.conv_and_pool(x,self.conv13) #(N,Co)
         x2 = self.conv_and_pool(x,self.conv14) #(N,Co)

--- a/mydatasets.py
+++ b/mydatasets.py
@@ -77,10 +77,10 @@ class MR(TarDataset):
         if examples is None:
             path = self.dirname if path is None else path
             examples = []
-            with open(os.path.join(path, 'rt-polarity.neg')) as f:
+            with open(os.path.join(path, 'rt-polarity.neg'), errors='ignore') as f:
                 examples += [
                     data.Example.fromlist([line, 'negative'], fields) for line in f]
-            with open(os.path.join(path, 'rt-polarity.pos')) as f:
+            with open(os.path.join(path, 'rt-polarity.pos'), errors='ignore') as f:
                 examples += [
                     data.Example.fromlist([line, 'positive'], fields) for line in f]
         super(MR, self).__init__(examples, fields, **kwargs)

--- a/train.py
+++ b/train.py
@@ -18,10 +18,13 @@ def train(train_iter, dev_iter, model, args):
             feature, target = batch.text, batch.label
             feature.data.t_(), target.data.sub_(1)  # batch first, index align
             if args.cuda:
-                feature, target = feature.cuda(), feature.cuda()
+                feature, target = feature.cuda(), target.cuda()
 
             optimizer.zero_grad()
             logit = model(feature)
+
+            #print('logit vector', logit.size())
+            #print('target vector', target.size())
             loss = F.cross_entropy(logit, target)
             loss.backward()
             optimizer.step()
@@ -52,7 +55,7 @@ def eval(data_iter, model, args):
         feature, target = batch.text, batch.label
         feature.data.t_(), target.data.sub_(1)  # batch first, index align
         if args.cuda:
-            feature, target = feature.cuda(), feature.cuda()
+            feature, target = feature.cuda(), target.cuda()
 
         logit = model(feature)
         loss = F.cross_entropy(logit, target, size_average=False)


### PR DESCRIPTION
Avoid error when reading to line 27 in file `rt-polaritydata/rt-polarity.neg`.

```
Loading data...
Traceback (most recent call last):
  File "main.py", line 71, in <module>
    train_iter, dev_iter = mr(text_field, label_field, device=-1, repeat=False)
  File "main.py", line 57, in mr
    train_data, dev_data = mydatasets.MR.splits(text_field, label_field)
  File "/home/yhhuang/cnn-text-classification-pytorch/mydatasets.py", line 105, in splits
    examples = cls(text_field, label_field, path=path, **kwargs).examples
  File "/home/yhhuang/cnn-text-classification-pytorch/mydatasets.py", line 82, in __init__
    data.Example.fromlist([line, 'negative'], fields) for line in f]
  File "/home/yhhuang/cnn-text-classification-pytorch/mydatasets.py", line 82, in <listcomp>
    data.Example.fromlist([line, 'negative'], fields) for line in f]
  File "/home/yhhuang/anaconda3/lib/python3.5/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97 in position 3118: invalid start byte
```