### PR TITLE
Fixed breaking changes in predict function introduced by pytorch 0.4

### DIFF
--- a/train.py
+++ b/train.py
@@ -87,8 +87,8 @@ def predict(text, model, text_field, label_feild, cuda_flag):
     # text = text_field.tokenize(text)
     text = text_field.preprocess(text)
     text = [[text_field.vocab.stoi[x] for x in text]]
-    x = text_field.tensor_type(text)
-    x = autograd.Variable(x, volatile=True)
+    x = torch.tensor(text)
+    x = autograd.Variable(x)
     if cuda_flag:
         x = x.cuda()
     print(x)


### PR DESCRIPTION
Pytorch 0.4 removes tensor_type from torchtext data field and causes predict function from train.py to break. 

Switched over to getting the tensor from torch based on the migration guide: https://pytorch.org/blog/pytorch-0_4_0-migration-guide/

